### PR TITLE
Add WS and WSS connection tests to the proxy integration test

### DIFF
--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/transports/netty/NettyServer.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/transports/netty/NettyServer.java
@@ -156,7 +156,7 @@ public abstract class NettyServer implements AutoCloseable {
         return handshakeComplete;
     }
 
-    protected URI getConnectionURI() throws Exception {
+    public URI getConnectionURI() throws Exception {
         if (!started.get()) {
             throw new IllegalStateException("Cannot get URI of non-started server");
         }

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/transports/netty/NettySimpleAmqpServer.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/transports/netty/NettySimpleAmqpServer.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.apache.qpid.jms.transports.TransportOptions;
 import org.apache.qpid.jms.util.IdGenerator;
@@ -284,7 +285,7 @@ public class NettySimpleAmqpServer extends NettyServer {
             protonConnection.open();
 
             if (connectionIntercepter != null) {
-                failure = connectionIntercepter.interceptConnectionAttempt(connection);
+                failure = connectionIntercepter.apply(connection);
             }
 
             if (failure == null) {
@@ -496,9 +497,11 @@ public class NettySimpleAmqpServer extends NettyServer {
         this.connectionIntercepter = connectionIntercepter;
     }
 
-    public interface ConnectionIntercepter {
+    @FunctionalInterface
+    public interface ConnectionIntercepter extends Function<Connection, ErrorCondition> {
 
-        ErrorCondition interceptConnectionAttempt(Connection connection);
+        @Override
+        ErrorCondition apply(Connection connection);
 
     }
 


### PR DESCRIPTION
Use the simple AMQP netty server implementation to add connection
tests using WS and WSS through the test proxy with SOCKS5 and
HTTP variants.